### PR TITLE
Fix editing bug for completed tasks

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -112,7 +112,7 @@
                         </div>
                     {% else %}
                         <div id = "todoitem_comp">
-                        <p><del>{{todo['title']}}</del></p>
+                        <p id="{{todo['id']}}"><del>{{todo['title']}}</del></p>
                         <button onclick="openPopup({{todo['id']}})"><i class="fa fa-pencil"></i></button>
                         <button><a href="/delete/{{todo['id']}}"><i class="fa fa-trash-o"></i></a></button>
                     </div>


### PR DESCRIPTION
## Summary
- enable editing completed todos by adding missing id attribute

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6879f19cafa08321bc27eac813fd3c87