### PR TITLE
Switch delete & complete actions to POST

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -25,13 +25,13 @@ def update():
     db.update({'title': new_text}, todo_db.id == int(todo_id))
     return redirect(url_for('todo.index'))
 
-@bp.route('/delete/<int:todo_id>')
+@bp.route('/delete/<int:todo_id>', methods=['POST'])
 def delete(todo_id):
     todo_db = Query()
     db.remove(todo_db.id == todo_id)
     return redirect(url_for('todo.index'))
 
-@bp.route('/complete/<int:todo_id>')
+@bp.route('/complete/<int:todo_id>', methods=['POST'])
 def complete(todo_id):
     todo_db = Query()
     db.update({'complete': True}, todo_db.id == todo_id)

--- a/templates/index.html
+++ b/templates/index.html
@@ -106,15 +106,21 @@
                     {% if todo['complete'] == False %}
                         <div id = "todoitem">
                         <p id = "{{todo['id']}}">{{todo['title']}}</p>
-                        <button><a href="/complete/{{todo['id']}}"> <i class="fa fa-check"></i></a></button>
+                        <form action="/complete/{{todo['id']}}" method="POST" style="display:inline">
+                            <button type="submit"><i class="fa fa-check"></i></button>
+                        </form>
                         <button onclick="openPopup({{todo['id']}})"><i class="fa fa-pencil"></i></button>
-                        <button><a href="/delete/{{todo['id']}}"><i class="fa fa-trash-o"></i></a></button>
+                        <form action="/delete/{{todo['id']}}" method="POST" style="display:inline">
+                            <button type="submit"><i class="fa fa-trash-o"></i></button>
+                        </form>
                         </div>
                     {% else %}
                         <div id = "todoitem_comp">
                         <p id="{{todo['id']}}"><del>{{todo['title']}}</del></p>
                         <button onclick="openPopup({{todo['id']}})"><i class="fa fa-pencil"></i></button>
-                        <button><a href="/delete/{{todo['id']}}"><i class="fa fa-trash-o"></i></a></button>
+                        <form action="/delete/{{todo['id']}}" method="POST" style="display:inline">
+                            <button type="submit"><i class="fa fa-trash-o"></i></button>
+                        </form>
                     </div>
                     {% endif %}
                     


### PR DESCRIPTION
## Summary
- restrict `/delete` and `/complete` routes to POST
- submit delete and complete via forms using POST

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688311356ea08321a809ef0852ac955e