### PR TITLE
Add Graphviz installer script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+# Update package list and install Graphviz
+sudo apt-get update
+sudo apt-get install -y graphviz


### PR DESCRIPTION
## Summary
- add a simple setup script to install Graphviz via `apt-get`

## Testing
- `pytest -q` *(fails: No module named 'tinydb')*

------
https://chatgpt.com/codex/tasks/task_e_6889d371624c832191ae9865c0219140